### PR TITLE
[ES-2216] GroupMembership

### DIFF
--- a/src/functions/getGroupMembership.js
+++ b/src/functions/getGroupMembership.js
@@ -1,0 +1,26 @@
+import ActiveDirectory from '@edifylabs/activedirectory';
+import { errors } from '../utils';
+
+export default async function getGroupMembership({ groups, filter, attributes, ldapConfig }) {
+  const ldapConnection = new ActiveDirectory(ldapConfig);
+  const options = attributes ? { attributes } : {};
+
+  const results = await Promise.all(groups.map((group) =>
+    new Promise((resolve, reject) => {
+      ldapConnection.getGroupMembershipForGroup(options, group, (err, result) => {
+        if (err) {
+          return reject(err);
+        }
+        return resolve({ [group]: result });
+      });
+    }).catch((err) => {
+      if (err.message.includes('connectTimeout')) {
+        throw new errors.RequestTimeout('Unable to connect to LDAP');
+      }
+
+      throw new errors.InternalError(`Error executing request: ${err.message}`);
+    }),
+  ));
+
+  return results.reduce((acc, result) => ({ ...acc, ...result }));
+}

--- a/src/functions/index.js
+++ b/src/functions/index.js
@@ -1,3 +1,4 @@
 export { default as getUsers } from './getUsers';
 export { default as getUser } from './getUser';
 export { default as getGroups } from './getGroups';
+export { default as getGroupMembership } from './getGroupMembership';


### PR DESCRIPTION
 listGroups with groups param returns groupMembershipForGroups

groupName can be either cn or dn
```
groups: ['role.subgroup', 'CN=role.group,CN=Users,DC=ad,DC=edify,DC=cx']
```